### PR TITLE
Add github workflow to build container images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,8 @@ jobs:
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64,linux/arm/v7
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Build container image
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.0.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.2.0
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to docker hub
+        uses: docker/login-action@v3.1.0
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5.3.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }}
+            docker.io/${{ github.repository_owner}}/${{ github.repository }}:latest
+            docker.io/${{ github.repository_owner}}/${{ github.repository }}:${{ github.sha }}


### PR DESCRIPTION
This PR adds a workflow to the repo to auto build the container image when commits/merges are made into `main`.

It will push to both GitHub Container Repository and DockerHub with the tag `latest` and the commit sha.

It will build images for the following platforms:
- `linux/amd64`
- `linux/arm64`
- `linux/arm/v7`

This requires two secrets to be set on the repository for push access to DockerHub:
- `DOCKER_USER`
- `DOCKER_PASSWORD`

GitHub container repository access is granted via the `permissions` definition inside the workflow.