### PR TITLE
Use multi-stage docker to shrink final image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,16 @@
+FROM golang:1.22-alpine3.18 as build
+
+RUN apk add --no-cache \
+  unzip
+
+RUN mkdir -p /app/bin
+# install Tesla Go packages
+ADD https://github.com/teslamotors/vehicle-command/archive/refs/heads/main.zip /tmp
+RUN unzip /tmp/main.zip -d /app
+WORKDIR /app/vehicle-command-main
+RUN go get ./...
+RUN go build -o /app/bin ./...
+
 FROM alpine:3.19.1
 
 # install dependencies
@@ -5,34 +18,24 @@ RUN apk add --no-cache \
   python3 \
   py3-flask \
   py3-requests \
-  go \
   gpg-agent \
   pass \
   openssl
 
 # Create various working directories
-RUN mkdir -p /app/templates /data /share
+RUN mkdir /data /share
 
 # Copy project files into required locations
 COPY tesla_http_proxy/app /app
-RUN chmod go+x /app/run.sh && chmod go+r /app/templates/* && chmod 0700 /app/config.sh
 
-# install Tesla Go packages
-ADD https://github.com/teslamotors/vehicle-command/archive/refs/heads/main.zip /tmp
-RUN unzip /tmp/main.zip -d /app
-WORKDIR /app/vehicle-command-main
-RUN go get ./... && \
-  go build ./... && \
-  go install ./...
-# installed to /root/go/bin/tesla-http-proxy
+# Copy tesla-http-proxy binary from build stage
+COPY --from=build /app/bin/tesla-http-proxy /app/bin/tesla-keygen /usr/bin/
 
 # Set environment variables
-ENV PATH="/root/go/bin:${PATH}"
 ENV GNUPGHOME="/data/gnugpg"
 ENV PASSWORD_STORE_DIR="/data/password-store"
 
-# Tidy up
-RUN rm -fr /app/vehicle-command-main /tmp/main.zip
-
 # Python 3 HTTP Server serves the current working dir
 WORKDIR /app
+
+ENTRYPOINT ["/app/run.sh"]

--- a/tesla_http_proxy/app/run.sh
+++ b/tesla_http_proxy/app/run.sh
@@ -32,7 +32,7 @@ generate_keypair() {
 
   # Generate keypair
   echo "Generating keypair"
-  /root/go/bin/tesla-keygen -f -keyring-type pass -key-name myself create >/share/com.tesla.3p.public-key.pem
+  tesla-keygen -f -keyring-type pass -key-name myself create >/share/com.tesla.3p.public-key.pem
   cat /share/com.tesla.3p.public-key.pem
 }
 
@@ -66,4 +66,4 @@ if ! [ -f /data/access_token ]; then
 fi
 
 echo "Starting Tesla HTTP Proxy"
-/root/go/bin/tesla-http-proxy -keyring-debug -keyring-type pass -key-name myself -cert /data/cert.pem -tls-key /data/key.pem -port 443 -host 0.0.0.0 -verbose
+tesla-http-proxy -keyring-debug -keyring-type pass -key-name myself -cert /data/cert.pem -tls-key /data/key.pem -port 443 -host 0.0.0.0 -verbose


### PR DESCRIPTION
Tidy up the Dockerfile and move building the tesla go apps in a stage so `go` does not have to be installed in final image.

```shell
$ docker images
ghcr.io/jesserockz/tesla-http-proxy-docker:multi-stage	d34dc71a8677  3 minutes ago  100MB
ghcr.io/jesserockz/tesla-http-proxy-docker:latest       2ac1f534c956  47 hours ago   613MB
```