### PR TITLE
Update webpage flow, accept cli args, decouple cert generation

### DIFF
--- a/tesla_http_proxy/app/run.sh
+++ b/tesla_http_proxy/app/run.sh
@@ -65,7 +65,7 @@ fi
 
 if ! [ -f /data/access_token ]; then
   echo "Starting temporary Python app for authentication flow. Delete /data/access_token to force regeneration in the future"
-  python3 /app/run.py
+  python3 /app/run.py --client-id "$CLIENT_ID" --client-secret "$CLIENT_SECRET" --domain "$DOMAIN" --region "$REGION" --proxy-host "$PROXY_HOST"
 fi
 
 echo "Starting Tesla HTTP Proxy"

--- a/tesla_http_proxy/app/templates/index.html
+++ b/tesla_http_proxy/app/templates/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <style>
@@ -7,10 +8,12 @@
             font-family: sans-serif;
             text-align: center;
         }
+
         div.content {
             width: 100%;
             padding: 10px;
         }
+
         button {
             padding: 10px;
             font-size: 14px;
@@ -18,20 +21,30 @@
         }
     </style>
 </head>
+
 <body>
     <h2>Tesla HTTP Proxy setup</h2>
     <hr>
     <div class="content">
-        <a href="https://auth.tesla.com/oauth2/v3/authorize?&client_id={{client_id}}&locale=en-US&prompt=login&redirect_uri=https://{{domain}}/callback&response_type=code&scope={{scopes}}&state={{randomstate}}&nonce={{randomnonce}}" target="_blank"><button type="button">Generate OAuth token</button></a>
+        <a href="https://auth.tesla.com/oauth2/v3/authorize?&client_id={{client_id}}&locale=en-US&prompt=login&redirect_uri=https://{{domain}}/callback&response_type=code&scope={{scopes}}&state={{randomstate}}&nonce={{randomnonce}}"
+            target="_blank"><button type="button">1. Generate OAuth token</button></a>
+    </div>
+
+    <div class="content">
+        <a href="https://{{domain}}/.well-known/appspecific/com.tesla.3p.public-key.pem" target="_blank"><button
+                type="button">2. Test public key endpoint</button></a>
     </div>
     <div class="content">
-        <a href="https://tesla.com/_ak/{{domain}}" target="_blank"><button type="button">Enroll public key in your vehicle</button></a>
+        <a href="generate-partner-token"><button type="button">3. Register Partner account<br />
+                (Make sure the above test works)</button></a>
     </div>
     <div class="content">
-        <a href="https://{{domain}}/.well-known/appspecific/com.tesla.3p.public-key.pem" target="_blank"><button type="button">Test public key endpoint</button></a>
+        <a href="https://tesla.com/_ak/{{domain}}" target="_blank"><button type="button">4. Enroll public key in your
+                vehicle</button></a>
     </div>
     <div class="content">
-        <a href="shutdown"><button type="button">Shutdown Flask server</button></a>
+        <a href="shutdown"><button type="button">5. Shutdown Flask server</button></a>
     </div>
 </body>
+
 </html>


### PR DESCRIPTION
There are 3 main changes in this PR

1. Update the webpage and its flow.
	The reason I moved the partner token generation into a new user initialised step is so that people (like myself) with proxy servers hosted elsewhere can manually copy the `com.tesla.3p.public-key.pem` file to their static hosting before instructing Tesla servers to pull it.
![2024-03-31_11-41](https://github.com/iainbullock/tesla-http-proxy-docker/assets/3060199/ed9e4666-1591-4c38-9fb2-2b3d8870558c)

2. Accepting CLI arguments.
	The current setup requires `config.sh` to be filled for the `run.sh` script to set up certs, but also requires env vars on the docker container so the python app can get the values. This adds cli args to the python script so that the run.sh script can send the args directly to it and the container no longer needs env vars set as well.

3. Decouple cert generation
	The SSL generation and tesla key generation were in the same function meaning regenerating one would regenerate both, which doesnt make sense as they are completely unrelated certificates/keys and can be generated by themselves with their own criteria.
