### PR TITLE
Update the auth URL to the new, fleet specific one required by Tesla.

### DIFF
--- a/tesla_http_proxy/app/run.py
+++ b/tesla_http_proxy/app/run.py
@@ -106,7 +106,7 @@ def callback():
 
     # Exchange code for refresh_token
     req = requests.post(
-        "https://auth.tesla.com/oauth2/v3/token",
+        "https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/token",
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         data={
             "grant_type": "authorization_code",
@@ -151,7 +151,7 @@ def register_partner_account():
     logger.info("*** Generating Partner Authentication Token ***")
 
     req = requests.post(
-        "https://auth.tesla.com/oauth2/v3/token",
+        "https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/token",
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         data={
             "grant_type": "client_credentials",

--- a/tesla_http_proxy/app/templates/index.html
+++ b/tesla_http_proxy/app/templates/index.html
@@ -26,7 +26,7 @@
     <h2>Tesla HTTP Proxy setup</h2>
     <hr>
     <div class="content">
-        <a href="https://auth.tesla.com/oauth2/v3/authorize?&client_id={{client_id}}&locale=en-US&prompt=login&redirect_uri=https://{{domain}}/callback&response_type=code&scope={{scopes}}&state={{randomstate}}&nonce={{randomnonce}}"
+        <a href="https://fleet-auth.prd.vn.cloud.tesla.com/oauth2/v3/authorize?&client_id={{client_id}}&locale=en-US&prompt=login&redirect_uri=https://{{domain}}/callback&response_type=code&scope={{scopes}}&state={{randomstate}}&nonce={{randomnonce}}"
             target="_blank"><button type="button">1. Generate OAuth token</button></a>
     </div>
 


### PR DESCRIPTION
Tesla sent out emails stating:

> Action Required: Update Fleet API Authentication Host
> Fleet API Partner,
> 
> Our logs show that your integration is still using https://auth.tesla.com/ for token exchange. As part of our ongoing improvements, we introduced a domain dedicated to Fleet API token exchange with increased rate limits and reliability: https://fleet-auth.prd.vn.cloud.tesla.com/. Please migrate to this domain in the next few weeks to avoid being rate limited.
> 
> Action required - Update the domain used for calls to /token endpoints by August 1st, 2025.
>
> No other changes are required - This is a host-only update for token acquisition. Credentials, Fleet API domains, existing authorizations, endpoints, streaming configurations all remain unchanged.

This PR simply updates the auth URLs to use the new host.