### PR TITLE
Fix ghcr publishing to nested package name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           cache-to: type=gha,mode=max
           push: true
           tags: |
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:latest
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}:${{ github.sha }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
             docker.io/iainbullock/tesla_http_proxy:latest
             docker.io/iainbullock/tesla_http_proxy:${{ github.ref_name }}


### PR DESCRIPTION
Before: `ghcr.io/<username>/<username>/tesla-http-proxy-docker`
After: `ghcr.io/<username>/tesla-http-proxy-docker`
