### PR TITLE
Fix case warning in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine3.22 as build
+FROM golang:1.25-alpine3.22 AS build
 
 RUN apk add --no-cache \
   unzip


### PR DESCRIPTION
Fixes `=> WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)`